### PR TITLE
Minimal suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,25 +9,37 @@ for pure replacement mods (lacking an ESP) will not be preserved when the respec
 
 When the save function is invoked, the INI and `Plugins` files will be modified accordingly and saved to the SD card.
 
+### Changes made to original work
+Change all suffix to be single letter only. For example, `EnaiRim - Textures` should now be formatted as `EnaiRim - T`.
+
+The skyrim.ini file has a line limit of 1024 characters, which can be hit very quickly if we use the lengthy original suffixes (I hit it around 16 mods, even with succinct base modnames).
+
+This change hence aims to remove all of that unnecessary character bloat from the skyrim.ini configuration file so that more mods can be loaded.
+
+### Naming Scheme (updated)
+
 Currently, the app requires that all mods follow a standard naming scheme:
 
+- All suffixes in filenames are to be truncated to one-letter only
+  - `Mod - Animations.bsa` to be renamed `Mod - A.bsa`
+  - `Mod - Meshes.bsa` to be renamed `Mod - M.bsa`
+  - `Mod - Sounds.bsa` to be renamed `Mod - S.bsa`
+  - `Mod - Textures.bsa` to be renamed `Mod - T.bsa`
+  - `Mod - Voices.bsa` to be renamed `Mod - V.bsa`
+  - Additional Tip: You can further replace the basename `Mod` with something even shorter like `M` - just use common sense and make sure it doesn't conflict with the basename of another mod.
+
 - BSA files with a suffix must use a hyphen with one space on either side between the base name and the suffix
-  - Example: `Static Mesh Improvement Mod - Textures.bsa`
+  - Example: `Static Mesh Improvement Mod - T.bsa`
   - Note that a mod may have exactly one non-suffixed BSA file
 - BSA files with an associated ESP file must match the ESP's name, not including the suffix
-  - Example: `Static Mesh Improvement Mod - Textures.bsa` matches `Static Mesh Improvement Mod.esp`
+  - Example: `Static Mesh Improvement Mod - T.bsa` matches `Static Mesh Improvement Mod.esp`
 - All BSA files for a given mod must match each other in name
-  - Example: `Static Mesh Improvement Mod - Textures.bsa` matches `Static Mesh Improvement Mod - Meshes.bsa`
+  - Example: `Static Mesh Improvement Mod - T.bsa` matches `Static Mesh Improvement Mod - M.bsa`
 
 ### To-do
 
-- Graceful error handling
-  - I've done minimal edge testing so far, so the app probably won't respond well to most less-than-ideal
-    conditions (e.g. missing or malformed files)
-- Proper graphical interface
-  - This isn't high priority since the console interface seems to work well enough for now
-- INI injection support
-  - Injecting INIs is easy; the hard part is disabling them in a sane way
+- Add ability to 'nickname' or give aliases to mods so that it's easier to identify truncated modnames.
+- Add a python or bash script to automatically to automatically detect and truncate all suffixes in a folder
 
 ### Building
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,15 @@ for pure replacement mods (lacking an ESP) will not be preserved when the respec
 
 When the save function is invoked, the INI and `Plugins` files will be modified accordingly and saved to the SD card.
 
-### Changes made to original work
-Change all suffix to be single letter only. For example, `EnaiRim - Textures` should now be formatted as `EnaiRim - T`.
+### Changes Made To Original Work
+1. Change all suffixes to be single letter only. 
+- For example, `EnaiRim - Textures` should now be formatted as `EnaiRim - T`.
 
-The skyrim.ini file has a line limit of 1024 characters, which can be hit very quickly if we use the lengthy original suffixes (I hit it around 16 mods, even with succinct base modnames).
+- The skyrim.ini file has a line limit of 1024 characters, which can be hit very quickly if we use the lengthy original suffixes scheme on NexusMods (I hit it around 16 mods, even with succinct base modnames).
 
-This change hence aims to remove all of that unnecessary character bloat from the skyrim.ini configuration file so that more mods can be loaded.
+- This change hence aims to remove all of that unnecessary character bloat from the `skyrim.ini` configuration file so that more mods can be loaded.
+
+2. Very small under-the-hood fixes
 
 ### Naming Scheme (updated)
 
@@ -38,7 +41,7 @@ Currently, the app requires that all mods follow a standard naming scheme:
 
 ### To-do
 
-- Add ability to 'nickname' or give aliases to mods so that it's easier to identify truncated modnames.
+- Add ability to 'nickname' or give aliases to mods in-app or on PC via a `.txt` so that it's easier to identify truncated modnames (so that you don't come back to the game after 5 years and start wondering what `E.esp` does)
 - Add a python or bash script to automatically to automatically detect and truncate all suffixes in a folder
 
 ### Building

--- a/include/mod.hpp
+++ b/include/mod.hpp
@@ -34,6 +34,12 @@
 #define EXT_ESM "esm"
 #define EXT_BSA "bsa"
 
+#define SUFFIX_ANIMATIONS "Animations"
+#define SUFFIX_MESHES "Meshes"
+#define SUFFIX_SOUNDS "Sounds"
+#define SUFFIX_TEXTURES "Textures"
+#define SUFFIX_VOICES "Voices"
+
 enum class ModStatus {
     ENABLED,
     DISABLED,

--- a/include/mod.hpp
+++ b/include/mod.hpp
@@ -34,11 +34,11 @@
 #define EXT_ESM "esm"
 #define EXT_BSA "bsa"
 
-#define SUFFIX_ANIMATIONS "Animations"
-#define SUFFIX_MESHES "Meshes"
-#define SUFFIX_SOUNDS "Sounds"
-#define SUFFIX_TEXTURES "Textures"
-#define SUFFIX_VOICES "Voices"
+#define SUFFIX_ANIMATIONS "A"
+#define SUFFIX_MESHES "M"
+#define SUFFIX_SOUNDS "S"
+#define SUFFIX_TEXTURES "T"
+#define SUFFIX_VOICES "V"
 
 enum class ModStatus {
     ENABLED,

--- a/src/ini_helper.cpp
+++ b/src/ini_helper.cpp
@@ -36,9 +36,9 @@
 #include <fstream>
 #include <memory>
 
-static const std::vector<std::string> g_archive_types_1 = {"", "Animations", "Meshes", "Sounds"};
-static const std::vector<std::string> g_archive_types_2 = {"Textures", "Voices"};
-static const std::vector<std::string> g_archive_types_3 = {"Animations"};
+static const std::vector<std::string> g_archive_types_1 = {"", SUFFIX_ANIMATIONS, SUFFIX_MESHES, SUFFIX_SOUNDS};
+static const std::vector<std::string> g_archive_types_2 = {SUFFIX_TEXTURES, SUFFIX_VOICES};
+static const std::vector<std::string> g_archive_types_3 = {SUFFIX_ANIMATIONS};
 
 static StdIni g_skyrim_ini;
 static StdIni g_skyrim_lang_ini;

--- a/src/ini_helper.cpp
+++ b/src/ini_helper.cpp
@@ -138,7 +138,7 @@ int processIniDefs(ModList &final_mod_list, ModList &temp_mod_list, StdIni &ini,
 
         bool good_suffix = false;
         for (std::string expected_suffix : expected_suffixes) {
-            if (mod_file.suffix.find_last_of(expected_suffix, expected_suffix.size())) {
+            if (mod_file.suffix == expected_suffix) {
                 good_suffix = true;
                 break;
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -269,9 +269,15 @@ static void redrawHeader(void) {
     CONSOLE_CLEAR_LINE();
     CONSOLE_SET_COLOR(CONSOLE_COLOR_FG_CYAN);
     printf("SkyMM-NX v" STRINGIZE(__VERSION) " by caseif");
+    CONSOLE_SET_COLOR(CONSOLE_COLOR_FG_MAGENTA);
+    printf(", modified by SundayReds");
+    CONSOLE_MOVE_DOWN(1);
+    CONSOLE_MOVE_LEFT(255);
     CONSOLE_SET_COLOR(CONSOLE_COLOR_FG_WHITE);
+    printf("NOTE: Shorten suffixes eg. 'Mod - Meshes.bsa' should be 'Mod - M.bsa'.");
 
-    CONSOLE_MOVE_DOWN(2);
+
+    CONSOLE_MOVE_DOWN(1);
     CONSOLE_MOVE_LEFT(255);
     printf(HRULE);
 }

--- a/src/mod.cpp
+++ b/src/mod.cpp
@@ -86,7 +86,7 @@ ModStatus SkyrimMod::getStatus(void) {
     } else {
         bool bad_anims = false;
         for (auto bsa_pair : enabled_bsas) {
-            if (bsa_pair.first.find("Animations") == 0 && bsa_pair.second != 2) {
+            if (bsa_pair.first.find(SUFFIX_ANIMATIONS) == 0 && bsa_pair.second != 2) {
                 bsa_status = ModStatus::PARTIAL;
                 bad_anims = true;
                 break;
@@ -114,7 +114,7 @@ ModStatus SkyrimMod::getStatus(void) {
 void SkyrimMod::enable(void) {
     enabled_bsas.clear();
     for (std::string bsa : bsa_suffixes) {
-        int count = bsa.find("Animations") == 0 ? 2 : 1;
+        int count = bsa.find(SUFFIX_ANIMATIONS) == 0 ? 2 : 1;
         enabled_bsas.insert(std::pair(bsa, count));
     }
 


### PR DESCRIPTION
Change all suffix to be single letter only. For example, `EnaiRim - Textures` should now be formatted as `EnaiRim - T`.

The `skyrim.ini` file has a line limit of 1024 characters, which can be hit very quickly if we use the lengthy original suffixes (I hit it around 16 mods, even with succinct base modnames). 

This change hence aims to remove all of that unnecessary character bloat from the `skyrim.ini` configuration file so that more mods can be loaded.